### PR TITLE
idiomatic improvements suggested by clippy

### DIFF
--- a/src/bin/ds_proxy.rs
+++ b/src/bin/ds_proxy.rs
@@ -44,8 +44,7 @@ struct Args {
 fn read_password(path: String) -> String {
     let file = File::open(path).unwrap();
     let reader = io::BufReader::new(file);
-    let line = reader.lines().nth(0).unwrap().unwrap();
-    line
+    reader.lines().nth(0).unwrap().unwrap()
 }
 
 fn create_config(args: &Args) -> Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,7 @@ impl Config {
     }
 
     pub fn create_key(self) -> Result<Key, &'static str> {
-        return match (self.password, self.salt) {
+        match (self.password, self.salt) {
             (Some(password), Some(input_salt)) => {
                 if let Some(salt) = Salt::from_slice(&input_salt.as_bytes()[..]) {
                     let mut raw_key = [0u8; KEYBYTES];
@@ -62,7 +62,7 @@ impl Config {
                 }
             }
             _ => Err("Password or salt is missing. Impossible to derive a key"),
-        };
+        }
     }
 
     pub fn create_url(&self, uri: &Uri) -> String {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -49,7 +49,7 @@ impl<E> Encoder<E> {
                     buf.extend(&[super::HEADER_DS_VERSION_NB]);
                     buf.extend(header_bytes);
 
-                    Ok(Async::Ready(Some(buf.into())))
+                    Ok(Async::Ready(Some(buf)))
                 },
 
                 Some(ref mut stream) => {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -12,7 +12,7 @@ use futures::stream::Stream;
 const TIMEOUT_DURATION:Duration = Duration::from_secs(600);
 
 // Encryption changes the value of those headers
-const HEADERS_TO_REMOVE: [actix_web::http::header::HeaderName; 3] = [
+static HEADERS_TO_REMOVE: [actix_web::http::header::HeaderName; 3] = [
     actix_web::http::header::CONTENT_LENGTH,
     actix_web::http::header::CONTENT_TYPE,
     actix_web::http::header::ETAG,


### PR DESCRIPTION
```
error: a const item should never be interior mutable
  --> src/proxy.rs:15:1
   |
15 |   const HEADERS_TO_REMOVE: [actix_web::http::header::HeaderName; 3] = [
   |   ^----
   |   |
   |  _help: make this a static item: `static`
   | |
16 | |     actix_web::http::header::CONTENT_LENGTH,
17 | |     actix_web::http::header::CONTENT_TYPE,
18 | |     actix_web::http::header::ETAG,
19 | | ];
   | |__^
   |
   = note: #[deny(clippy::declare_interior_mutable_const)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const
```

```
warning: identical conversion
  --> src/encoder.rs:52:42
   |
52 |                     Ok(Async::Ready(Some(buf.into())))
   |                                          ^^^^^^^^^^ help: consider removing `.into()`: `buf`
   |
   = note: #[warn(clippy::identity_conversion)] on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
```

```
warning: this `else { if .. }` block can be collapsed
   --> src/decoder.rs:117:24
    |
117 |                   } else {
    |  ________________________^
118 | |                     if self.inner_ended {
119 | |                         trace!("inner stream over, decrypting whats left");
120 | |                         let rest = self.buffer.len();
...   |
127 | |                     }
128 | |                 }
    | |_________________^
    |
    = note: #[warn(clippy::collapsible_if)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if%
```