### PR TITLE
include binary version via git commit hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "encrypt"
 version = "0.1.0"
 authors = ["simon lehericey <mail@simon.lehericey.net>"]
 edition = "2018"
+build = "build.rs" # Cargo only supports one build script per project at the moment
 
 [dependencies]
 sodiumoxide = "0.2.2"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+/*
+build script for the project
+*/
+fn main() {
+    // taken from https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
+    let output = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/src/bin/ds_proxy.rs
+++ b/src/bin/ds_proxy.rs
@@ -12,9 +12,11 @@ fn main() {
     env_logger::init();
     sodiumoxide::init().unwrap();
 
-    let args: Args = Docopt::new(USAGE)
-        .and_then(|d| d.deserialize())
-        .unwrap_or_else(|e| e.exit());
+    let docopt: Docopt = Docopt::new(USAGE)
+        .unwrap_or_else(|e| e.exit())
+        .version(Some(env!("GIT_HASH").to_string()));
+
+    let args: Args = docopt.deserialize().unwrap_or_else(|e| e.exit());
 
     let config: Config = Config::create_config(&args);
 


### PR DESCRIPTION
Maintenant `ds_proxy --version` renvoie le hash du commit qui a servi à compiler