### PR TITLE
Add rustfmt to circle-ci checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@
       - image: circleci/rust:1.40.0
     steps:
       - checkout
+      - run: rustup component add rustfmt
+      - run:
+          name: "Code linter"
+          command: |
+            cargo fmt -- --check
       - run:
           name: "Update Node.js and npm"
           command: |


### PR DESCRIPTION
Perform a lint check as part of the CI, using [rustfmt](https://github.com/rust-lang/rustfmt).