### PR TITLE
ci: run the linter on another ci job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
- version: 2
- jobs:
-  build:
+version: 2
+jobs:
+  lint:
     docker:
       - image: circleci/rust:1.40.0
     steps:
@@ -10,13 +10,25 @@
           name: "Code linter"
           command: |
             cargo fmt -- --check
+  test:
+    docker:
+      - image: circleci/rust:1.40.0
+    steps:
+      - checkout
       - run:
           name: "Update Node.js and npm"
           command: |
             curl -sSL "https://nodejs.org/dist/v11.10.0/node-v11.10.0-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v11.10.0-linux-x64/bin/node
             curl https://www.npmjs.com/install.sh | sudo bash
       - run:
-          name: "Install node depenencies"
+          name: "Install node dependencies"
           command: |
             cd tests/fixtures/server-static && npm install
       - run: cargo test
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - lint
+      - test


### PR DESCRIPTION
Right now, when the linter fail, CircleCI tells us that the whole build failed.

This PR allows the CI to quickly report if the linter or tests failed.